### PR TITLE
fix(gaud-poll): replace dashboard in-place instead of stacking

### DIFF
--- a/packages/gaud-poll/package.json
+++ b/packages/gaud-poll/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builtby.win/gaud-poll",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Polling daemon for gaud-mode — monitors tmux specialist panes for GAUDMODE callbacks and stuck states",
   "keywords": ["gaud", "gaud-mode", "tmux", "polling", "callbacks"],
   "author": "builtby-win",

--- a/packages/gaud-poll/src/agent-dashboard.ts
+++ b/packages/gaud-poll/src/agent-dashboard.ts
@@ -209,7 +209,11 @@ export class AgentDashboard {
       if (i < lineCount - 1) process.stderr.write("\n");
     }
 
-    this.renderedLines = lines.length;
+    // Clear anything from cursor to end of screen — ensures no residual
+    // lines from a previous larger render or unexpected stderr output.
+    process.stderr.write("\x1b[J");
+
+    this.renderedLines = lineCount;
     this.frame = (this.frame + 1) % FRAMES.length;
   }
 
@@ -220,6 +224,7 @@ export class AgentDashboard {
       process.stderr.write(CLEAR_LINE);
       if (i < this.renderedLines - 1) process.stderr.write("\n");
     }
+    process.stderr.write("\x1b[J");
     this.renderedLines = 0;
   }
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `agent-dashboard.ts` that caused the TUI dashboard to stack on itself instead of replacing content in-place.

### Root cause 1: `renderedLines` tracks wrong value

`renderedLines` was set to `lines.length` instead of `lineCount` (which is `Math.max(lines.length, renderedLines)`). When the dashboard grew — e.g. agent detail wrapped to more lines — the next render's cursor-up offset (`\x1b[N A`) used the old smaller count, so content was written partway through the old block. This left stale lines visible above, creating the "double dashboard" appearance.

### Root cause 2: no clear-to-end-of-screen

Neither `render()` nor `clearRenderedBlock()` issued `\x1b[J` after writing, so residual lines from a previous larger render or any unexpected stderr output persisted below the dashboard.

### Fix

- `this.renderedLines = lineCount` (was `lines.length`)
- `process.stderr.write("\x1b[J")` at end of both `render()` and `clearRenderedBlock()`
- Bump gaud-poll `0.2.2` → `0.2.3`